### PR TITLE
Add NuGet workflow, and update package info

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,50 @@
+name: NuGet
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  nuget-1:
+    name: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.100
+          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Pack
+        run: |
+          dotnet pack -c Release --output nupkgs BinaryRecords/BinaryRecords.csproj
+      - name: Publish
+        run: |
+          dotnet nuget push nupkgs/BinaryRecords.*.nupkg -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate
+
+  nuget-2:
+    name: https://api.nuget.org/v3/index.json
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.100
+          source-url: https://api.nuget.org/v3/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_KEY}}
+      - name: Pack
+        run: |
+          dotnet pack -c Release --output nupkgs BinaryRecords/BinaryRecords.csproj
+      - name: Publish
+        run: |
+          dotnet nuget push nupkgs/BinaryRecords.*.nupkg -k ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/BinaryRecords/BinaryRecords.csproj
+++ b/BinaryRecords/BinaryRecords.csproj
@@ -3,6 +3,13 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>9</LangVersion>
+    <Version>0.1.0</Version>
+    <Authors>chandler14362</Authors>
+    <Description>Library for serializing the C# 9 record types with no attributes or type registration.</Description>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/chandler14362/BinaryRecords</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>serialization;contractless;high-performance;span;memory;c#9</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,5 +18,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Krypton.Buffers" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will push to both GitHub packages, and nuget.org.

All that's required is a repository secret named `NUGET_API_KEY` containing your nuget.org API key.
